### PR TITLE
Implement apt pinning for Debian-based hosts

### DIFF
--- a/provision/modules/puppet/manifests/apt_pin.pp
+++ b/provision/modules/puppet/manifests/apt_pin.pp
@@ -1,0 +1,27 @@
+# == Class: puppet::apt_pin
+#
+# This class pins the puppet package versions so installing specific versions
+# of Puppet can work on Debian/Ubuntu hosts.
+#
+# === Parameters
+#
+# [*version*]
+#   Which version that puppet packages should be pinned to.
+#
+class puppet::apt_pin(
+  $version
+) {
+  file { 'puppet.pref':
+    path    => '/etc/apt/preferences.d/puppet.pref',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('puppet/puppet_apt_pin.pref.erb')
+  }
+
+  # Ensure the pinning file exists before packages are installed
+  Class['puppet::apt_pin'] -> Package['puppet']
+  if defined(Package['puppetmaster']) {
+    Class['puppet::apt_pin'] -> Package['puppetmaster']
+  }
+}

--- a/provision/modules/puppet/manifests/init.pp
+++ b/provision/modules/puppet/manifests/init.pp
@@ -28,6 +28,12 @@ class puppet(
   $ensure = $puppet::params::client_ensure
 ) inherits puppet::params {
 
+  if $osfamily == 'debian' and $ensure != 'latest' {
+    class { 'puppet::apt_pin':
+      version => $ensure
+    }
+  }
+
   package { 'puppet':
     ensure => $ensure,
   }

--- a/provision/modules/puppet/templates/puppet_apt_pin.pref.erb
+++ b/provision/modules/puppet/templates/puppet_apt_pin.pref.erb
@@ -1,0 +1,5 @@
+# puppet packages
+Explanation: pin puppet packages to desired version
+Package: puppet puppet-common puppetmaster puppetmaster-common
+Pin: version <%= version %>
+Pin-Priority: 1000


### PR DESCRIPTION
Hi there! I was working on a sandbox for a puppet 2.7 environment and found that I couldn't specify the puppet version for debian-based hosts. This should fix it.

I attempted to match the style used in the repo. Any feedback is welcome.

Cheers!

Paul
