### PR TITLE
Remove File defaults so code under test can use them

### DIFF
--- a/provision/modules/puppet/files/site.pp
+++ b/provision/modules/puppet/files/site.pp
@@ -3,6 +3,3 @@
 #
 
 import 'nodes'
-
-# global defaults
-File { backup => '.original' }


### PR DESCRIPTION
With this resource default in place, code under test which sets the
backup parameter on File cannot compile. It seems reasonable to kill the
backups here, since we're dealing with ephemeral vagrant boxes anyways.
