### PR TITLE
install of puppet via apt failed on debian based systems due to missing repos in apt list

### DIFF
--- a/provision/modules/mirrors/templates/puppetlabs.list.erb
+++ b/provision/modules/mirrors/templates/puppetlabs.list.erb
@@ -1,2 +1,2 @@
-deb http://apt.puppetlabs.com <%= lsbdistcodename %> main
-deb-src http://apt.puppetlabs.com <%= lsbdistcodename %> main
+deb http://apt.puppetlabs.com <%= lsbdistcodename %> main dependencies
+deb-src http://apt.puppetlabs.com <%= lsbdistcodename %> main dependencies


### PR DESCRIPTION
I found that the apt puppet package requires puppet-common, and that package is now in the dependencies repo, but the repo list was just using the main repo.

it seems in the 3.x releases puppet labs restructured the repo layout.

I updated the puppet labs apt repo list to include the 'dependencies' source, and now puppet will install on debian nodes. 
