### PR TITLE
use a key server that has the required apt key

### DIFF
--- a/provision/modules/repos/manifests/apt.pp
+++ b/provision/modules/repos/manifests/apt.pp
@@ -22,7 +22,7 @@ class repos::apt {
   exec { 'apt_key_puppetlabs':
     path    => '/bin:/usr/bin',
     unless  => "/usr/bin/apt-key list | /bin/grep -q '${puppetlabs_key}'",
-    command => "apt-key adv --keyserver 'pgp.mit.edu' --recv-keys '${puppetlabs_key}'",
+    command => "apt-key adv --keyserver 'keyserver.ubuntu.com' --recv-keys '${puppetlabs_key}'",
     before  => File[ 'puppetlabs.list' ],
   }
 


### PR DESCRIPTION

~~~
root@ops-002:/home/vagrant# apt-key adv --keyserver 'pgp.mit.edu' --recv-keys '4BD6EC30'
Executing: gpg --ignore-time-conflict --no-options --no-default-keyring --secret-keyring /tmp/tmp.3HdqVQQnPb --trustdb-name /etc/apt//trustdb.gpg --keyring /etc/apt/trusted.gpg --primary-keyring /etc/apt/trusted.gpg --keyring /etc/apt/trusted.gpg.d//debian-archive-squeeze-automatic.gpg --keyring /etc/apt/trusted.gpg.d//debian-archive-squeeze-stable.gpg --keyring /etc/apt/trusted.gpg.d//debian-archive-wheezy-automatic.gpg --keyring /etc/apt/trusted.gpg.d//debian-archive-wheezy-stable.gpg --keyserver pgp.mit.edu --recv-keys 4BD6EC30
gpg: requesting key 4BD6EC30 from hkp server pgp.mit.edu
gpgkeys: key 4BD6EC30 not found on keyserver
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0

root@ops-002:/home/vagrant# apt-key adv --keyserver keyserver.ubuntu.com --recv 4BD6EC30
Executing: gpg --ignore-time-conflict --no-options --no-default-keyring --secret-keyring /tmp/tmp.HgStDKphNt --trustdb-name /etc/apt//trustdb.gpg --keyring /etc/apt/trusted.gpg --primary-keyring /etc/apt/trusted.gpg --keyring /etc/apt/trusted.gpg.d//debian-archive-squeeze-automatic.gpg --keyring /etc/apt/trusted.gpg.d//debian-archive-squeeze-stable.gpg --keyring /etc/apt/trusted.gpg.d//debian-archive-wheezy-automatic.gpg --keyring /etc/apt/trusted.gpg.d//debian-archive-wheezy-stable.gpg --keyserver keyserver.ubuntu.com --recv 4BD6EC30
gpg: requesting key 4BD6EC30 from hkp server keyserver.ubuntu.com
gpg: key 4BD6EC30: public key "Puppet Labs Release Key (Puppet Labs Release Key) <info@puppetlabs.com>" imported
gpg: key 4BD6EC30: public key "Puppet Labs Release Key (Puppet Labs Release Key) <info@puppetlabs.com>" imported
gpg: no ultimately trusted keys found
gpg: Total number processed: 2
gpg:               imported: 2  (RSA: 2)

