### PR TITLE
Set timeout = 0 on exec apt-get update

### DIFF
--- a/provision/modules/repos/manifests/apt.pp
+++ b/provision/modules/repos/manifests/apt.pp
@@ -39,6 +39,7 @@ class repos::apt {
     command     => '/usr/bin/apt-get update',
     subscribe   => File[ 'puppetlabs.list' ],
     refreshonly => true,
+    timeout     => 0,
   }
 
 }


### PR DESCRIPTION
This will avoid timeout with slow networks.