### PR TITLE
Remove typo in atlas URL

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
   puppet_nodes.each do |node|
     config.vm.define node[:hostname] do |node_config|
       node_config.vm.box = node[:box]
-      node_config.vm.box_url = 'https://atlas.hasicorp.com/' + node_config.vm.box
+      node_config.vm.box_url = 'https://atlas.hashicorp.com/' + node_config.vm.box
       node_config.vm.hostname = node[:hostname] + '.' + domain
       node_config.vm.network :private_network, ip: node[:ip]
 


### PR DESCRIPTION
Typo in the file on line 18; missing second "h" in the url for hashicorp. Breaks "vagrant up" when no ubuntu/trusty64 box already present.

#Original
      node_config.vm.box_url = 'https://atlas.hasicorp.com/' + node_config.vm.box

#Fixed
      node_config.vm.box_url = 'https://atlas.hashicorp.com/' + node_config.vm.box