### PR TITLE
Fixes atlas hashicorp deprecated url

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
   puppet_nodes.each do |node|
     config.vm.define node[:hostname] do |node_config|
       node_config.vm.box = node[:box]
-      node_config.vm.box_url = 'https://atlas.hashicorp.com/' + node_config.vm.box
+      node_config.vm.box_url = 'https://vagrantcloud.com/' + node_config.vm.box
       node_config.vm.hostname = node[:hostname] + '.' + domain
       node_config.vm.network :private_network, ip: node[:ip]
 


### PR DESCRIPTION
```
pathcl@polonio:~/src$ git clone https://github.com/elasticdog/puppet-sandbox
Cloning into 'puppet-sandbox'...
remote: Counting objects: 248, done.
remote: Total 248 (delta 0), reused 0 (delta 0), pack-reused 248
Receiving objects: 100% (248/248), 46.91 KiB | 0 bytes/s, done.
Resolving deltas: 100% (70/70), done.
Checking connectivity... done.
pathcl@polonio:~/src$ cd puppet-sandbox/
pathcl@polonio:~/src/puppet-sandbox$ vagrant up
Bringing machine 'puppet' up with 'virtualbox' provider...
Bringing machine 'client1' up with 'virtualbox' provider...
Bringing machine 'client2' up with 'virtualbox' provider...
==> puppet: Box 'ubuntu/trusty64' could not be found. Attempting to find and install...
    puppet: Box Provider: virtualbox
    puppet: Box Version: >= 0
==> puppet: Box file was not detected as metadata. Adding it directly...
==> puppet: Adding box 'ubuntu/trusty64' (v0) for provider: virtualbox
    puppet: Downloading: https://atlas.hashicorp.com/ubuntu/trusty64
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

The requested URL returned error: 404 Not Found
```
Uhm lets see inside Vagrantifle..

```
pathcl@polonio:~/src/puppet-sandbox$ vim Vagrantfile
```

Now it is working again

```
pathcl@polonio:~/src/puppet-sandbox$ vagrant up
Bringing machine 'puppet' up with 'virtualbox' provider...
Bringing machine 'client1' up with 'virtualbox' provider...
Bringing machine 'client2' up with 'virtualbox' provider...
==> puppet: Box 'ubuntu/trusty64' could not be found. Attempting to find and install...
    puppet: Box Provider: virtualbox
    puppet: Box Version: >= 0
==> puppet: Loading metadata for box 'https://vagrantcloud.com/ubuntu/trusty64'
    puppet: URL: https://vagrantcloud.com/ubuntu/trusty64
==> puppet: Adding box 'ubuntu/trusty64' (v20180627.0.1) for provider: virtualbox
    puppet: Downloading: https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/20180627.0.1/providers/virtualbox.box
    puppet: Progress: 4% (Rate: 3861k/s, Estimated time remaining: 0:02:10)^C==> puppet: Waiting for cleanup before exiting...
==> puppet: Box download was interrupted. Exiting.
The box failed to unpackage properly. Please verify that the box
file you're trying to add is not corrupted and try again. The
output from attempting to unpackage (if any):

x box.ovf
x Vagrantfile
x box-disk1.vmdk: Truncated tar archive
bsdtar: Error exit delayed from previous errors.

pathcl@polonio:~/src/puppet-sandbox$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   Vagrantfile

no changes added to commit (use "git add" and/or "git commit -a")
pathcl@polonio:~/src/puppet-sandbox$ git add .
pathcl@polonio:~/src/puppet-sandbox$ git commit -m "Fixes atlas hashicorp deprecated url"
[master 6fcfbca] Fixes atlas hashicorp deprecated url
 1 file changed, 1 insertion(+), 1 deletion(-)
pathcl@polonio:~/src/puppet-sandbox$ git push
Username for 'https://github.com': pathcl
Password for 'https://pathcl@github.com':
Counting objects: 3, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 322 bytes | 0 bytes/s, done.
Total 3 (delta 2), reused 0 (delta 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
To https://github.com/pathcl/puppet-sandbox
   cca4a92..6fcfbca  master -> master
pathcl@polonio:~/src/puppet-sandbox$ vagrant up
Bringing machine 'puppet' up with 'virtualbox' provider...
Bringing machine 'client1' up with 'virtualbox' provider...
Bringing machine 'client2' up with 'virtualbox' provider...
==> puppet: Box 'ubuntu/trusty64' could not be found. Attempting to find and install...
    puppet: Box Provider: virtualbox
    puppet: Box Version: >= 0
==> puppet: Loading metadata for box 'https://vagrantcloud.com/ubuntu/trusty64'
    puppet: URL: https://vagrantcloud.com/ubuntu/trusty64
==> puppet: Adding box 'ubuntu/trusty64' (v20180627.0.1) for provider: virtualbox
    puppet: Downloading: https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/20180627.0.1/providers/virtualbox.box
==> puppet: Box download is resuming from prior download progress
==> puppet: Successfully added box 'ubuntu/trusty64' (v20180627.0.1) for 'virtualbox'!
==> puppet: Importing base box 'ubuntu/trusty64'...
```